### PR TITLE
Fixed saving tags in add_snip

### DIFF
--- a/hufflepuff/code_snips/forms.py
+++ b/hufflepuff/code_snips/forms.py
@@ -12,6 +12,10 @@ class SnippetForm(forms.ModelForm):
             'language',
             'tags',
         ]
+    tags = forms.ModelMultipleChoiceField(
+        queryset=Tag.objects.all(),
+        widget=forms.CheckboxSelectMultiple
+    )
 
 
 class CommentForm(forms.ModelForm):

--- a/hufflepuff/code_snips/forms.py
+++ b/hufflepuff/code_snips/forms.py
@@ -14,7 +14,7 @@ class SnippetForm(forms.ModelForm):
         ]
     tags = forms.ModelMultipleChoiceField(
         queryset=Tag.objects.all(),
-        widget=forms.CheckboxSelectMultiple
+        widget=forms.CheckboxSelectMultiple()
     )
 
 

--- a/hufflepuff/code_snips/forms.py
+++ b/hufflepuff/code_snips/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from code_snips.models import Comment, Snippet
+from code_snips.models import Comment, Snippet, Tag
 
 
 class SnippetForm(forms.ModelForm):
@@ -18,3 +18,9 @@ class CommentForm(forms.ModelForm):
     class Meta:
         model = Comment
         fields = ['text',]
+
+
+class TagForm(forms.ModelForm):
+    class Meta:
+        model = Tag
+        fields = ['name',]

--- a/hufflepuff/code_snips/views.py
+++ b/hufflepuff/code_snips/views.py
@@ -3,7 +3,7 @@ from django.http.response import JsonResponse
 from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib.auth.decorators import login_required
 from .models import Snippet, Comment
-from .forms import SnippetForm, CommentForm
+from .forms import SnippetForm, CommentForm, TagForm
 import datetime
 # Create your views here.
 
@@ -38,14 +38,19 @@ def code_view(request, pk):
 def add_snip(request):
   if request.method == 'GET':
     form = SnippetForm()
+    tag_form = TagForm()
   else:
     form = SnippetForm(data=request.POST)
-    if form.is_valid():
+    tag_form = TagForm(data=request.POST)
+    if tag_form.is_valid():
+      tag_form.save()
+      return redirect('add_snip')
+    elif form.is_valid():
       snippet_form = form.save(commit=False)
       snippet_form.created_by = request.user
       snippet_form.save()
       return redirect('user_page')
-  return render(request, 'code_snips/add_snip.html', {'form': form})
+  return render(request, 'code_snips/add_snip.html', {'form': form, 'tag_form': tag_form})
 
 @login_required
 def edit_snip(request, pk):

--- a/hufflepuff/code_snips/views.py
+++ b/hufflepuff/code_snips/views.py
@@ -38,19 +38,20 @@ def code_view(request, pk):
 def add_snip(request):
   if request.method == 'GET':
     form = SnippetForm()
-    tag_form = TagForm()
+    # tag_form = TagForm()
   else:
     form = SnippetForm(data=request.POST)
-    tag_form = TagForm(data=request.POST)
-    if tag_form.is_valid():
-      tag_form.save()
-      return redirect('add_snip')
-    elif form.is_valid():
+    # tag_form = TagForm(data=request.POST)
+    # if tag_form.is_valid():
+    #   tag_form.save()
+    #   return redirect('add_snip')
+    if form.is_valid():
       snippet_form = form.save(commit=False)
       snippet_form.created_by = request.user
       snippet_form.save()
+      form.save_m2m()
       return redirect('user_page')
-  return render(request, 'code_snips/add_snip.html', {'form': form, 'tag_form': tag_form})
+  return render(request, 'code_snips/add_snip.html', {'form': form})
 
 @login_required
 def edit_snip(request, pk):

--- a/hufflepuff/code_snips/views.py
+++ b/hufflepuff/code_snips/views.py
@@ -57,12 +57,17 @@ def edit_snip(request, pk):
   snippet = get_object_or_404(Snippet, pk=pk)
   if request.method == 'GET':
     form = SnippetForm(instance=snippet)
+    tag_form = TagForm()
   else:
     form = SnippetForm(data=request.POST, instance=snippet)
-    if form.is_valid():
+    tag_form = TagForm(data=request.POST)
+    if tag_form.is_valid():
+      tag_form.save()
+      return redirect('edit_snip', pk=pk)
+    elif form.is_valid():
       form.save()
       return redirect('user_page')
-  return render(request, 'code_snips/edit_snip.html', {'form': form, 'snippet': snippet})
+  return render(request, 'code_snips/edit_snip.html', {'form': form, 'tag_form': tag_form, 'snippet': snippet})
 
 @login_required
 def delete_snip(request, pk):

--- a/hufflepuff/code_snips/views.py
+++ b/hufflepuff/code_snips/views.py
@@ -18,6 +18,7 @@ def user_page(request):
   authored = Snippet.objects.filter(created_by=request.user)
   return render(request, 'code_snips/user_page.html', {"favorites": favorites, "authored": authored})
 
+@login_required
 def code_view(request, pk):
   snippet = get_object_or_404(Snippet, pk=pk)
   comments = Comment.objects.filter(snippet=snippet).order_by('-created_at')
@@ -66,16 +67,19 @@ def delete_snip(request, pk):
     return redirect('user_page')
   return render(request, 'code_snips/delete_snip.html', {'snippet': snippet})
 
+@login_required
 def filter_by_tag(request, tag):
   snippets=Snippet.objects.filter(tags__name=tag)
   snippets.order_by('-created_at')
   return render(request, 'code_snips/filtered_page.html', {"snippets":snippets, "tag":tag})
 
+@login_required
 def filter_by_language(request, language):
   snippets=Snippet.objects.filter(language__name=language)
   snippets.order_by('-created_at')
   return render(request, 'code_snips/by_language.html', {"snippets":snippets, "language":language})
 
+@login_required
 def search_by_title(request):
     # get the search term from the query params
     query = request.GET.get("q")
@@ -85,16 +89,19 @@ def search_by_title(request):
 
     return render(request, "code_snips/home.html", {"snippets": results})
 
+@login_required
 def search_by_language(request):
   query = request.GET.get("q")
   results = Snippet.objects.filter(language__name__icontains=query)
   return render(request, "code_snips/home.html", {"snippets": results})
 
+@login_required
 def search_by_tag(request):
   query = request.GET.get("q")
   results = Snippet.objects.filter(tags__name__icontains=query)
   return render(request, "code_snips/home.html", {"snippets": results})
 
+@login_required
 def search_by_user(request):
   query = request.GET.get("q")
   results = Snippet.objects.filter(created_by__username__icontains=query)

--- a/hufflepuff/static/js/tags_display.js
+++ b/hufflepuff/static/js/tags_display.js
@@ -1,0 +1,7 @@
+const tags = document.querySelectorAll('label')
+for (let tag of tags) {
+    tag.classList.add("pa3")
+}
+
+const unlist = document.getElementById('id_tags')
+unlist.setAttribute("class", "list courier flex flex-wrap justify-center items-center")

--- a/hufflepuff/templates/code_snips/add_snip.html
+++ b/hufflepuff/templates/code_snips/add_snip.html
@@ -57,6 +57,22 @@ Add Snippet
             <button class="f6 grow no-underline br-pill ba bw2 ph3 pv2 mb2 dib black sans-serif" type="submit">Save Changes</button>
         </div>
     </form>
+    <form action="{% url 'add_snip' %}" method='POST'>
+        {% csrf_token %}
+        <article class="center mw5 mw7-ns hidden ba mv4">
+            <div class="pa3 bt flex items-center">
+                <p class="f6 f5-ns lh-copy mv0 courier w-25 center">
+                    New Tag:
+                </p>
+                <p class="f6 f5-ns lh-copy mv0 courier w-75">
+                    {{ tag_form.name }}
+                </p>
+            </div>
+        </article>
+        <div class="flex justify-center">
+            <button class="f6 grow no-underline br-pill ba bw2 ph3 pv2 mb2 dib black sans-serif" type="submit">Add Tag</button>
+        </div>
+    </form>
 </div>
 
 {% endblock %}

--- a/hufflepuff/templates/code_snips/add_snip.html
+++ b/hufflepuff/templates/code_snips/add_snip.html
@@ -1,8 +1,14 @@
 {% extends 'base.html' %}
 
+{% load static %}
+
 {% block title %}
 Add Snippet
 {% endblock title %}
+
+{% block javascript %}
+<script src="{% static 'js/tags_display.js' %}" defer></script>
+{% endblock javascript %}
 
 {% block content %}
 
@@ -49,7 +55,7 @@ Add Snippet
                     Tags:
                 </p>
                 <p class="f6 f5-ns lh-copy mv0 courier w-75">
-                    {{ form.tags }}
+                     {{ form.tags }} 
                 </p>
             </div>
         </article>

--- a/hufflepuff/templates/code_snips/add_snip.html
+++ b/hufflepuff/templates/code_snips/add_snip.html
@@ -55,7 +55,7 @@ Add Snippet
                     Tags:
                 </p>
                 <p class="f6 f5-ns lh-copy mv0 courier w-75">
-                     {{ form.tags }} 
+                    {{ form.tags }}
                 </p>
             </div>
         </article>

--- a/hufflepuff/templates/code_snips/edit_snip.html
+++ b/hufflepuff/templates/code_snips/edit_snip.html
@@ -56,6 +56,22 @@ Edit Snippet
             <button class="f6 grow no-underline br-pill ba bw2 ph3 pv2 mb2 dib black sans-serif" type="submit">Save Changes</button>
         </div>
     </form>
+    <form action="{% url 'edit_snip' pk=snippet.pk %}" method='POST'>
+        {% csrf_token %}
+        <article class="center mw5 mw7-ns hidden ba mv4">
+            <div class="pa3 bt flex items-center">
+                <p class="f6 f5-ns lh-copy mv0 courier w-25 center">
+                    New Tag:
+                </p>
+                <p class="f6 f5-ns lh-copy mv0 courier w-75">
+                    {{ tag_form.name }}
+                </p>
+            </div>
+        </article>
+        <div class="flex justify-center">
+            <button class="f6 grow no-underline br-pill ba bw2 ph3 pv2 mb2 dib black sans-serif" type="submit">Add Tag</button>
+        </div>
+    </form>
 </div>
 
 {% endblock %}

--- a/hufflepuff/templates/code_snips/edit_snip.html
+++ b/hufflepuff/templates/code_snips/edit_snip.html
@@ -1,8 +1,14 @@
 {% extends 'base.html' %}
 
+{% load static %}
+
 {% block title %}
 Edit Snippet
 {% endblock title %}
+
+{% block javascript %}
+<script src="{% static 'js/tags_display.js' %}" defer></script>
+{% endblock javascript %}
 
 {% block content %}
 <div>


### PR DESCRIPTION
Adding a new snip now saves the associated tags using the .save_m2m() method.